### PR TITLE
Update manifest when copying assets

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -1,7 +1,13 @@
-Rake::Task['assets:precompile:primary'].enhance do
-  assets = File.expand_path(File.dirname(__FILE__) + "/../../vendor/assets/javascripts/tinymce")
-  target = File.join(Rails.public_path, Rails.application.config.assets.prefix)
+assets_task = Rake::Task.task_defined?('assets:precompile:primary') ? 'assets:precompile:primary' : 'assets:precompile'
 
-  mkdir_p target
-  cp_r assets, target
+Rake::Task[assets_task].enhance do
+  require "tinymce/rails/asset_installer"
+
+  assets = Pathname.new(File.expand_path(File.dirname(__FILE__) + "/../../vendor/assets/javascripts/tinymce"))
+
+  config   = Rails.application.config
+  target   = File.join(Rails.public_path, config.assets.prefix)
+  manifest = config.assets.manifest
+
+  TinyMCE::Rails::AssetInstaller.new(assets, target, manifest).install
 end


### PR DESCRIPTION
If the [pull request #104](https://github.com/spohlenz/tinymce-rails/pull/104) in [tinymce-rails](https://github.com/spohlenz/tinymce-rails) is getting merged, this pull request should prevent assets from getting deleted by the Capistrano `deploy:assets:clean_expired` task. (The same problem was once reported and fixed in spohlenz/tinymce-rails#83.)

The changes in this pull request are basically copied from the [lib/tasks/tinymce-assets.rake](https://github.com/spohlenz/tinymce-rails/blob/master/lib/tasks/tinymce-assets.rake) file in [tinymce-rails](https://github.com/spohlenz/tinymce-rails).

Please have a look. Thanks! :smile: 
