### PR TITLE
Update assets.rake task to fix precompile

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -9,5 +9,7 @@ Rake::Task[assets_task].enhance do
   target   = File.join(Rails.public_path, config.assets.prefix)
   manifest = config.assets.manifest
 
-  TinyMCE::Rails::AssetInstaller.new(assets, target, manifest).install
+  installer = TinyMCE::Rails::AssetInstaller.new(assets, target, manifest)
+  installer.strategy = config.tinymce.install
+  installer.install
 end


### PR DESCRIPTION
Using same install strategy as tinymce to fix asset precompilation.

Signed-off-by: Gabriel Oliveira <gabriel.oliveira@unicv.com.br>