### PR TITLE
Fix undefined method 'assets' on Rails 3.2

### DIFF
--- a/lib/tinymce/rails/languages.rb
+++ b/lib/tinymce/rails/languages.rb
@@ -1,5 +1,7 @@
 module TinyMCE::Rails
   class Languages < ::Rails::Engine
-    config.assets.precompile << "tinymce-rails-langs.manifest.js" # Sprockets 4 manifest
+    if config.respond_to? (:assets)
+      config.assets.precompile << "tinymce-rails-langs.manifest.js" # Sprockets 4 manifest
+    end
   end
 end


### PR DESCRIPTION
I've come across an error using the gem on Rails 3.2. When running the assets:precompile the flowing error appears:
```
rake assets:precompile --trace
rake aborted!
NoMethodError: undefined method `assets' for #<Rails::Engine::Configuration:0x007ffff31b6fe8>
/home/rachu/.rvm/gems/ruby-2.0.0-p648/gems/railties-3.2.22.5/lib/rails/railtie/configuration.rb:85:in `method_missing'
/home/rachu/.rvm/gems/ruby-2.0.0-p648/gems/tinymce-rails-langs-5.20200505/lib/tinymce/rails/languages.rb:3:in `<class:Languages>'
```

I've been able to workaround  it with the following change in 
tinymce-rails-langs/lib/tinymce/rails/languages.rb :

```
module TinyMCE::Rails
  class Languages < ::Rails::Engine
    if config.respond_to? (:assets)
      config.assets.precompile << "tinymce-rails-langs.manifest.js" # Sprockets 4 manifest
    end
  end
end
```